### PR TITLE
Fixed bug with conditional statements

### DIFF
--- a/codegen.c
+++ b/codegen.c
@@ -213,19 +213,23 @@ int generate(struct token *rootToken,char *code){
 						struct token *original = rootToken;
 						struct symbol *locSymbol = malloc(sizeof(struct symbol));
 						int dtype = dtLaH(rootToken,&root_symbol,locSymbol,1);
-						if (dtype == INTEGER || dtype == 1){
-							writeType(&code,&sz,INTEGER);
-							tmpSymbol->dataType = INTEGER;
-						} else if (dtype == FLOAT_ || dtype == 3){
-							writeType(&code,&sz,FLOAT_);
-							tmpSymbol->dataType = FLOAT_;
-						} else if (dtype == STRING || dtype == 2){
-							writeType(&code,&sz,STRING);
-							tmpSymbol->dataType = STRING;
+						if (dtype != -2){
+							if (dtype == INTEGER || dtype == 1){
+								writeType(&code,&sz,INTEGER);
+								tmpSymbol->dataType = INTEGER;
+							} else if (dtype == FLOAT_ || dtype == 3){
+								writeType(&code,&sz,FLOAT_);
+								tmpSymbol->dataType = FLOAT_;
+							} else if (dtype == STRING || dtype == 2){
+								writeType(&code,&sz,STRING);
+								tmpSymbol->dataType = STRING;
+							} else {
+								tmpSymbol->dataType = locSymbol->dataType;
+								writeType(&code,&sz,tmpSymbol->dataType);
+							} 
 						} else {
-							tmpSymbol->dataType = locSymbol->dataType;
 							writeType(&code,&sz,tmpSymbol->dataType);
-						} 
+						}
 					} else {
 						if (rootToken->value[0] == ';'){ // ugly I know :'(
 							strcpy(code + sz,";");
@@ -291,7 +295,6 @@ int generate(struct token *rootToken,char *code){
 				}
 				char repr[] = "{.type=%d,.%s=";
 				char repr2[500];
-				printf("%d--\n",dtype);
 				if (dtype == FLOAT_){
 					sprintf(repr2,repr,FLOAT_,"float_");
 				} else if (dtype == INTEGER) {
@@ -426,6 +429,7 @@ int generate(struct token *rootToken,char *code){
 		}
 	} while (rootToken != NULL);
 	code[sz] = '\0';
+	printf("Compiled.\n");
 	return 0;
 }
 


### PR DESCRIPTION
Input:
```javascript
var child1 = "John";
var child2 = "Johnson"; // creative.. I know :)
var child1_age = 16;
var child2_age = 16;

if child1_age > child2_age:
	print(child1_age);
end
elif child1_age == child2_age:
	print("They are the same age");
end
else:
	print(child2_age);
end
```
Output (before):
```
Unknown type
Fix the errors
```
Now:
cml 
```
Compiled.
````
c output
```c
#include <stdio.h>
 struct mt_object {int type;int integer;float float_;char *string;};
 int main() {
 struct mt_object child1 = {.type=30,.string="John"};
  struct mt_object child2 = {.type=30,.string="Johnson"};
  struct mt_object child1_age = {.type=40,.integer=16};
  struct mt_object child2_age = {.type=40,.integer=16};
  if(child1_age.integer  > child2_age.integer ) {
  	printf("%d\n",child1_age.integer ) ; 
  }else if(child1_age.integer  == child2_age.integer ) {
  	printf("%s\n","They are the same age") ; 
  }else{
  	printf("%d\n",child2_age.integer ) ; 
  } 
}
```
